### PR TITLE
Correctly set online map provider on startup

### DIFF
--- a/src/com/androzic/Androzic.java
+++ b/src/com/androzic/Androzic.java
@@ -1634,6 +1634,8 @@ public class Androzic extends BaseApplication
 					if (provider != null)
 					{
 						onlineMaps.add(provider);
+				        if (current.equals(provider.code))
+					        curProvider = provider;
 					}
 				}
 			    reader.close();


### PR DESCRIPTION
Without this patch, if you set your online map provider in settings to a custom provider (from providers.dat), everytime Androzic starts it will switch back to OpenStreetMaps. This small patch fixes this bug.
